### PR TITLE
extend the output fields with talon specific fields, useful if the payload is forwarded to a third party like AWS Lambda

### DIFF
--- a/actionners/actionners.go
+++ b/actionners/actionners.go
@@ -351,7 +351,10 @@ func StartConsumer(eventsC <-chan string) {
 			metrics.IncreaseCounter(log)
 
 			for _, a := range i.GetActions() {
-				if err := runAction(i, a, event); err != nil && a.IgnoreErrors == falseStr {
+				e := new(events.Event)
+				*e = *event
+				i.ExtendOutputFields(e, a)
+				if err := runAction(i, a, e); err != nil && a.IgnoreErrors == falseStr {
 					break
 				}
 				if a.Continue == falseStr || a.Continue != trueStr && !GetDefaultActionners().FindActionner(a.GetActionner()).MustDefaultContinue() {

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -43,7 +43,7 @@ func DecodeEvent(payload io.Reader) (*Event, error) {
 	}
 
 	if event.Source == "" {
-		event.Source = "syscalls"
+		event.Source = "syscall"
 	}
 
 	if event.TraceID == "" {

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -50,8 +51,9 @@ type outputfield struct {
 }
 
 const (
-	trueStr  string = "true"
-	falseStr string = "false"
+	trueStr               string = "true"
+	falseStr              string = "false"
+	falcoTalonOutputField string = "falco-talon."
 )
 
 var rules *[]*Rule
@@ -526,4 +528,24 @@ func (rule *Rule) comparePriority(event *events.Event) bool {
 		}
 	}
 	return false
+}
+
+func (rule *Rule) ExtendOutputFields(event *events.Event, action *Action) {
+	event.OutputFields[falcoTalonOutputField+"rule"] = rule.Name
+	if rule.Continue != "" {
+		event.OutputFields[falcoTalonOutputField+"rule.continue"] = rule.Continue
+	}
+	if rule.DryRun != "" {
+		event.OutputFields[falcoTalonOutputField+"rule.dry_run"] = rule.DryRun
+	}
+	event.OutputFields[falcoTalonOutputField+"action"] = action.Name
+	if action.Continue != "" {
+		event.OutputFields[falcoTalonOutputField+"action.continue"] = action.Continue
+	}
+	if action.IgnoreErrors != "" {
+		event.OutputFields[falcoTalonOutputField+"action.ignore_errors"] = action.IgnoreErrors
+	}
+	j, _ := json.Marshal(action.Parameters)
+	event.OutputFields[falcoTalonOutputField+"action.parameters"] = string(j)
+	event.OutputFields[falcoTalonOutputField+"actionner"] = action.Actionner
 }

--- a/rules.yaml
+++ b/rules.yaml
@@ -21,8 +21,6 @@
     aws_lambda_alias_or_version: $LATEST
     aws_lambda_invocation_type: RequestResponse
 
-
-
 - rule: Suspicious outbound connection
   match:
     rules:
@@ -41,22 +39,22 @@
   actions:
     - action: Labelize Pod as Suspicious
 
-- rule: Test invoke lambda
-  match:
-    rules:
-      - Test invoke lambda
-  actions:
-    - action: Invoke Lambda function
+# - rule: Test invoke lambda
+#   match:
+#     rules:
+#       - Test invoke lambda
+#   actions:
+#     - action: Invoke Lambda function
 
-- rule: Delete unknown namespace
-  match:
-    rules:
-      - K8s Namespace Created
-    output_fields:
-      - ka.target.namespace=todelete
-  actions:
-      - action: Delete the namespace
-        actionner: kubernetes:delete
+# - rule: Delete unknown namespace
+#   match:
+#     rules:
+#       - K8s Namespace Created
+#     output_fields:
+#       - ka.target.namespace=todelete
+#   actions:
+#       - action: Delete the namespace
+#         actionner: kubernetes:delete
   
 - rule: Calico netpol 
   match:


### PR DESCRIPTION
It extends the output fields in the falco payload with these intels:

- falco_talon.rule
- falco_talon.action
- falco_talon.rule.continue (true|false)
- falco_talon.rule.dry_run (true|false)
- falco_talon.action.continue (true|false)
- falco_talon.action.ignore_errors (true|false)
- falco_talon.actionner
- falco_talon.parameters (json)
