### PR TITLE
allow to use env vars in the exec/script, all the key fields (priority, rule, tags, output_fields, ...) of the falco event are exported + consider '-' as the value to remove a label

### DIFF
--- a/actionners/kubernetes/exec/exec.go
+++ b/actionners/kubernetes/exec/exec.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/remotecommand"
@@ -37,6 +38,9 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 	if parameters["command"] != nil {
 		*command = parameters["command"].(string)
 	}
+
+	event.ExportEnvVars()
+	*command = os.ExpandEnv(*command)
 
 	client := kubernetes.GetClient()
 

--- a/actionners/kubernetes/labelize/labelize.go
+++ b/actionners/kubernetes/labelize/labelize.go
@@ -40,6 +40,9 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 		if fmt.Sprintf("%v", j) == "" {
 			continue
 		}
+		if fmt.Sprintf("%v", j) == "-" {
+			continue
+		}
 		payload = append(payload, patch{
 			Op:    "replace",
 			Path:  metadataLabels + i,
@@ -63,7 +66,7 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 	payload = make([]patch, 0)
 	action.GetParameters()
 	for i, j := range parameters["labels"].(map[string]interface{}) {
-		if fmt.Sprintf("%v", j) != "" {
+		if fmt.Sprintf("%v", j) != "-" {
 			continue
 		}
 		payload = append(payload, patch{

--- a/actionners/kubernetes/script/script.go
+++ b/actionners/kubernetes/script/script.go
@@ -52,6 +52,9 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 		*script = string(fileContent)
 	}
 
+	event.ExportEnvVars()
+	*script = os.ExpandEnv(*script)
+
 	reader := strings.NewReader(*script)
 
 	client := kubernetes.GetClient()


### PR DESCRIPTION
The key elements of the falco events are now exported as env vars to be able to be used in `kubernetes;exec`, `kubernetes:script` actionners.

This allow to use the context of the events in the command/script.

For example, if the event contains `proc.pid: 9999`, we could set the action like this:

```yaml
  actions:
    - action: test command
      actionner: kubernetes:exec
      parameters:
        command: echo "kill -9 ${PROC_PID}"
```

---

Consider `-` as the value to remove a label, I noticed that if the value is empty, when the control plane creates the rules file from the configmap, the key is ignored.