### PR TITLE
better labels for the netpol

### DIFF
--- a/actionners/calico/networkpolicy/networkpolicy.go
+++ b/actionners/calico/networkpolicy/networkpolicy.go
@@ -19,6 +19,7 @@ import (
 )
 
 const mask32 string = "/32"
+const managedByStr string = "app.kubernetes.io/managed-by"
 
 func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 	podName := event.GetPodName()
@@ -33,6 +34,7 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 	k8sClient := kubernetes.GetClient()
 	calicoClient := calico.GetClient()
 
+	var err error
 	pod, err := k8sClient.GetPod(podName, namespace)
 	if err != nil {
 		return utils.LogLine{
@@ -103,7 +105,7 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 	delete(labels, "pod-template-hash")
 	delete(labels, "pod-template-generation")
 	delete(labels, "controller-revision-hash")
-	labels["app.kubernetes.io/managed-by"] = utils.FalcoTalonStr
+	labels[managedByStr] = utils.FalcoTalonStr
 
 	payload := networkingv3.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -123,7 +125,9 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 
 	var selector string
 	for i, j := range labels {
-		selector += fmt.Sprintf(`%v == "%v" && `, i, j)
+		if i != managedByStr {
+			selector += fmt.Sprintf(`%v == "%v" && `, i, j)
+		}
 	}
 
 	payload.Spec.Selector = strings.TrimSuffix(selector, " && ")
@@ -141,30 +145,31 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 	}
 
 	var output string
-	netpol, err := calicoClient.ProjectcalicoV3().NetworkPolicies(namespace).Get(context.Background(), owner, metav1.GetOptions{})
+	var netpol *networkingv3.NetworkPolicy
+	netpol, err = calicoClient.ProjectcalicoV3().NetworkPolicies(namespace).Get(context.Background(), owner, metav1.GetOptions{})
 	if errorsv1.IsNotFound(err) {
 		payload.Spec.Egress = []networkingv3.Rule{*denyRule}
 		payload.Spec.Egress = append(payload.Spec.Egress, *allowRule)
-		_, err = calicoClient.ProjectcalicoV3().NetworkPolicies(namespace).Create(context.Background(), &payload, metav1.CreateOptions{})
-		if errorsv1.IsAlreadyExists(err) {
-			netpol, err = calicoClient.ProjectcalicoV3().NetworkPolicies(namespace).Get(context.Background(), owner, metav1.GetOptions{}) //nolint:golint,staticcheck
-		}
-		output = fmt.Sprintf("the networkpolicy '%v' in the namespace '%v' has been created", owner, namespace)
-	} else if err == nil {
-		payload.ObjectMeta.ResourceVersion = netpol.ObjectMeta.ResourceVersion
-		var denyCIDR []string
-		for _, i := range netpol.Spec.Egress {
-			if i.Action == "Deny" {
-				denyCIDR = append(denyCIDR, i.Destination.Nets...)
+		_, err2 := calicoClient.ProjectcalicoV3().NetworkPolicies(namespace).Create(context.Background(), &payload, metav1.CreateOptions{})
+		if err2 != nil {
+			if !errorsv1.IsAlreadyExists(err2) {
+				return utils.LogLine{
+						Objects: objects,
+						Error:   err2.Error(),
+						Status:  "failure",
+					},
+					err2
 			}
+			netpol, err = calicoClient.ProjectcalicoV3().NetworkPolicies(namespace).Get(context.Background(), owner, metav1.GetOptions{})
+		} else {
+			output = fmt.Sprintf("the caliconetworkpolicy '%v' in the namespace '%v' has been created", owner, namespace)
+			return utils.LogLine{
+					Objects: objects,
+					Output:  output,
+					Status:  "success",
+				},
+				nil
 		}
-		denyCIDR = append(denyCIDR, event.GetRemoteIP()+mask32)
-		denyCIDR = utils.Deduplicate(denyCIDR)
-		denyRule = createDenyEgressRule(denyCIDR)
-		payload.Spec.Egress = []networkingv3.Rule{*denyRule}
-		payload.Spec.Egress = append(payload.Spec.Egress, *allowRule)
-		_, err = calicoClient.ProjectcalicoV3().NetworkPolicies(namespace).Update(context.Background(), &payload, metav1.UpdateOptions{})
-		output = fmt.Sprintf("the networkpolicy '%v' in the namespace '%v' has been updated", owner, namespace)
 	}
 	if err != nil {
 		return utils.LogLine{
@@ -174,7 +179,30 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 			},
 			err
 	}
+	payload.ObjectMeta.ResourceVersion = netpol.ObjectMeta.ResourceVersion
+	var denyCIDR []string
+	for _, i := range netpol.Spec.Egress {
+		if i.Action == "Deny" {
+			denyCIDR = append(denyCIDR, i.Destination.Nets...)
+		}
+	}
+	denyCIDR = append(denyCIDR, event.GetRemoteIP()+mask32)
+	denyCIDR = utils.Deduplicate(denyCIDR)
+	denyRule = createDenyEgressRule(denyCIDR)
+	payload.Spec.Egress = []networkingv3.Rule{*denyRule}
+	payload.Spec.Egress = append(payload.Spec.Egress, *allowRule)
+	_, err = calicoClient.ProjectcalicoV3().NetworkPolicies(namespace).Update(context.Background(), &payload, metav1.UpdateOptions{})
+	if err != nil {
+		return utils.LogLine{
+				Objects: objects,
+				Error:   err.Error(),
+				Status:  "failure",
+			},
+			err
+	}
+	output = fmt.Sprintf("the caliconetworkpolicy '%v' in the namespace '%v' has been updated", owner, namespace)
 	objects["NetworkPolicy"] = owner
+
 	return utils.LogLine{
 			Objects: objects,
 			Output:  output,

--- a/actionners/calico/networkpolicy/networkpolicy.go
+++ b/actionners/calico/networkpolicy/networkpolicy.go
@@ -101,6 +101,9 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 	}
 
 	delete(labels, "pod-template-hash")
+	delete(labels, "pod-template-generation")
+	delete(labels, "controller-revision-hash")
+	labels["app.kubernetes.io/managed-by"] = utils.FalcoTalonStr
 
 	payload := networkingv3.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -120,10 +123,10 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 
 	var selector string
 	for i, j := range labels {
-		selector += fmt.Sprintf(`%v == "%v" &&`, i, j)
+		selector += fmt.Sprintf(`%v == "%v" && `, i, j)
 	}
 
-	payload.Spec.Selector = strings.TrimSuffix(selector, " &&")
+	payload.Spec.Selector = strings.TrimSuffix(selector, " && ")
 
 	allowRule := createAllowEgressRule(action)
 	denyRule := createDenyEgressRule([]string{event.GetRemoteIP() + mask32})

--- a/actionners/kubernetes/networkpolicy/networkpolicy.go
+++ b/actionners/kubernetes/networkpolicy/networkpolicy.go
@@ -97,6 +97,9 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 	}
 
 	delete(labels, "pod-template-hash")
+	delete(labels, "pod-template-generation")
+	delete(labels, "controller-revision-hash")
+	labels["app.kubernetes.io/managed-by"] = utils.FalcoTalonStr
 
 	payload := networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/actionners/kubernetes/networkpolicy/networkpolicy.go
+++ b/actionners/kubernetes/networkpolicy/networkpolicy.go
@@ -99,7 +99,9 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 	delete(labels, "pod-template-hash")
 	delete(labels, "pod-template-generation")
 	delete(labels, "controller-revision-hash")
-	labels["app.kubernetes.io/managed-by"] = utils.FalcoTalonStr
+
+	labelsSelector := labels
+	labelsSelector["app.kubernetes.io/managed-by"] = utils.FalcoTalonStr
 
 	payload := networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -110,7 +112,7 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 		Spec: networkingv1.NetworkPolicySpec{
 			PolicyTypes: []networkingv1.PolicyType{"Egress"},
 			PodSelector: metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: labelsSelector,
 			},
 		},
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,6 +17,8 @@ import (
 )
 
 const (
+	FalcoTalonStr string = "falco-talon"
+
 	BoolStr           string = "bool"
 	FloatStr          string = "float"
 	Float64Str        string = "float64"


### PR DESCRIPTION
Add a `app.kubernetes.io/managed-by` label in the networkpolicy + clean up of the logic for the netpol update with for calico