### PR TITLE
add new parameter 'level' in kubernetes:labelize to allow to labelize the node

### DIFF
--- a/actionners/actionners.go
+++ b/actionners/actionners.go
@@ -7,6 +7,7 @@ import (
 	lambdaInvoke "github.com/falco-talon/falco-talon/actionners/aws/lambda"
 
 	calicoNetworkpolicy "github.com/falco-talon/falco-talon/actionners/calico/networkpolicy"
+	k8sCordon "github.com/falco-talon/falco-talon/actionners/kubernetes/cordon"
 	k8sDelete "github.com/falco-talon/falco-talon/actionners/kubernetes/delete"
 	k8sExec "github.com/falco-talon/falco-talon/actionners/kubernetes/exec"
 	k8sLabel "github.com/falco-talon/falco-talon/actionners/kubernetes/label"
@@ -133,6 +134,17 @@ func GetDefaultActionners() *Actionners {
 				},
 				CheckParameters: nil,
 				Action:          k8sDelete.Action,
+			},
+			&Actionner{
+				Category:        "kubernetes",
+				Name:            "cordon",
+				DefaultContinue: true,
+				Init:            k8s.Init,
+				Checks: []checkActionner{
+					k8sChecks.CheckPodExist,
+				},
+				CheckParameters: nil,
+				Action:          k8sCordon.Action,
 			},
 			&Actionner{
 				Category:        "aws",

--- a/actionners/kubernetes/cordon/cordon.go
+++ b/actionners/kubernetes/cordon/cordon.go
@@ -1,0 +1,68 @@
+package cordon
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/falco-talon/falco-talon/internal/events"
+	kubernetes "github.com/falco-talon/falco-talon/internal/kubernetes/client"
+	"github.com/falco-talon/falco-talon/internal/rules"
+	"github.com/falco-talon/falco-talon/utils"
+)
+
+const (
+	jsonPatch = `[{"op": "replace", "path": "/spec/unschedulable", "value": true}]`
+)
+
+func Action(_ *rules.Action, event *events.Event) (utils.LogLine, error) {
+	podName := event.GetPodName()
+	namespace := event.GetNamespaceName()
+
+	objects := map[string]string{}
+
+	client := kubernetes.GetClient()
+
+	pod, err := client.GetPod(podName, namespace)
+	if err != nil {
+		objects["pod"] = podName
+		objects["namespace"] = namespace
+		return utils.LogLine{
+				Objects: objects,
+				Error:   err.Error(),
+				Status:  "failure",
+			},
+			err
+	}
+
+	node, err := client.GetNodeFromPod(pod)
+	if err != nil {
+		return utils.LogLine{
+				Objects: objects,
+				Error:   err.Error(),
+				Status:  "failure",
+			},
+			err
+	}
+
+	objects["node"] = node.Name
+
+	_, err = client.Clientset.CoreV1().Nodes().Patch(context.Background(), node.Name, types.JSONPatchType, []byte(jsonPatch), metav1.PatchOptions{})
+	if err != nil {
+		return utils.LogLine{
+				Objects: objects,
+				Error:   err.Error(),
+				Status:  "failure",
+			},
+			err
+	}
+
+	return utils.LogLine{
+			Objects: objects,
+			Output:  fmt.Sprintf("the node '%v' has been cordoned", node.Name),
+			Status:  "success",
+		},
+		nil
+}

--- a/actionners/kubernetes/label/label.go
+++ b/actionners/kubernetes/label/label.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -23,19 +24,52 @@ type patch struct {
 
 const (
 	metadataLabels = "/metadata/labels/"
+	podStr         = "pod"
+	nodeStr        = "node"
 )
 
 func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
-	pod := event.GetPodName()
+	podName := event.GetPodName()
 	namespace := event.GetNamespaceName()
 
-	objects := map[string]string{
-		"pod":       pod,
-		"namespace": namespace,
-	}
+	objects := map[string]string{}
 
 	payload := make([]patch, 0)
 	parameters := action.GetParameters()
+
+	client := kubernetes.GetClient()
+
+	var err error
+	var kind string
+	var node *corev1.Node
+
+	if parameters["level"] == nodeStr {
+		kind = parameters["level"].(string)
+		pod, err2 := client.GetPod(podName, namespace)
+		if err2 != nil {
+			return utils.LogLine{
+					Objects: objects,
+					Error:   err2.Error(),
+					Status:  "failure",
+				},
+				err2
+		}
+		node, err = client.GetNodeFromPod(pod)
+		if err != nil {
+			return utils.LogLine{
+					Objects: objects,
+					Error:   err.Error(),
+					Status:  "failure",
+				},
+				err
+		}
+		objects[nodeStr] = node.Name
+	} else {
+		kind = podStr
+		objects[podStr] = podName
+		objects["namespace"] = namespace
+	}
+
 	for i, j := range parameters["labels"].(map[string]interface{}) {
 		if fmt.Sprintf("%v", j) == "" {
 			continue
@@ -47,10 +81,13 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 		})
 	}
 
-	client := kubernetes.GetClient()
-
 	payloadBytes, _ := json.Marshal(payload)
-	_, err := client.Clientset.CoreV1().Pods(namespace).Patch(context.Background(), pod, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+	if kind == podStr {
+		_, err = client.Clientset.CoreV1().Pods(namespace).Patch(context.Background(), podName, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+	}
+	if kind == nodeStr {
+		_, err = client.Clientset.CoreV1().Nodes().Patch(context.Background(), node.Name, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+	}
 	if err != nil {
 		return utils.LogLine{
 				Objects: objects,
@@ -73,7 +110,11 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 	}
 
 	payloadBytes, _ = json.Marshal(payload)
-	_, err = client.Clientset.CoreV1().Pods(namespace).Patch(context.Background(), pod, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+	if kind == nodeStr {
+		_, err = client.Clientset.CoreV1().Nodes().Patch(context.Background(), node.Name, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+	} else {
+		_, err = client.Clientset.CoreV1().Pods(namespace).Patch(context.Background(), podName, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+	}
 	if err != nil {
 		if err.Error() != "the server rejected our request due to an error in our request" {
 			return utils.LogLine{
@@ -84,9 +125,15 @@ func Action(action *rules.Action, event *events.Event) (utils.LogLine, error) {
 				err
 		}
 	}
+	var output string
+	if kind == nodeStr {
+		output = fmt.Sprintf("the node '%v' has been labelized", node.Name)
+	} else {
+		output = fmt.Sprintf("the pod '%v' in the namespace '%v' has been labelized", podName, namespace)
+	}
 	return utils.LogLine{
 			Objects: objects,
-			Output:  fmt.Sprintf("the pod '%v' in the namespace '%v' has been labelled", pod, namespace),
+			Output:  output,
 			Status:  "success",
 		},
 		nil

--- a/internal/kubernetes/client/client.go
+++ b/internal/kubernetes/client/client.go
@@ -122,6 +122,14 @@ func (client Client) GetReplicaSet(name, namespace string) (*appsv1.ReplicaSet, 
 	return p, nil
 }
 
+func (client Client) GetNode(name string) (*corev1.Node, error) {
+	p, err := client.Clientset.CoreV1().Nodes().Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("the node '%v' doesn't exist", name)
+	}
+	return p, nil
+}
+
 func (client Client) GetDeploymentFromPod(pod *corev1.Pod) (*appsv1.Deployment, error) {
 	podName := pod.OwnerReferences[0].Name
 	namespace := pod.ObjectMeta.Namespace
@@ -130,7 +138,7 @@ func (client Client) GetDeploymentFromPod(pod *corev1.Pod) (*appsv1.Deployment, 
 		return nil, err
 	}
 	if r == nil {
-		return nil, fmt.Errorf("can't find the deployment for the pod'%v' in namespace '%v'", pod, namespace)
+		return nil, fmt.Errorf("can't find the deployment for the pod'%v' in namespace '%v'", podName, namespace)
 	}
 	return r, nil
 }
@@ -143,7 +151,7 @@ func (client Client) GetDaemonsetFromPod(pod *corev1.Pod) (*appsv1.DaemonSet, er
 		return nil, err
 	}
 	if r == nil {
-		return nil, fmt.Errorf("can't find the daemonset for the pod'%v' in namespace '%v'", pod, namespace)
+		return nil, fmt.Errorf("can't find the daemonset for the pod'%v' in namespace '%v'", podName, namespace)
 	}
 	return r, nil
 }
@@ -156,7 +164,7 @@ func (client Client) GetStatefulsetFromPod(pod *corev1.Pod) (*appsv1.StatefulSet
 		return nil, err
 	}
 	if r == nil {
-		return nil, fmt.Errorf("can't find the statefulset for the pod'%v' in namespace '%v'", pod, namespace)
+		return nil, fmt.Errorf("can't find the statefulset for the pod'%v' in namespace '%v'", podName, namespace)
 	}
 	return r, nil
 }
@@ -169,7 +177,21 @@ func (client Client) GetReplicasetFromPod(pod *corev1.Pod) (*appsv1.ReplicaSet, 
 		return nil, err
 	}
 	if r == nil {
-		return nil, fmt.Errorf("can't find the replicaset for the pod'%v' in namespace '%v'", pod, namespace)
+		return nil, fmt.Errorf("can't find the replicaset for the pod'%v' in namespace '%v'", podName, namespace)
+	}
+	return r, nil
+}
+
+func (client Client) GetNodeFromPod(pod *corev1.Pod) (*corev1.Node, error) {
+	podName := pod.OwnerReferences[0].Name
+	namespace := pod.ObjectMeta.Namespace
+	nodeName := pod.Spec.NodeName
+	r, err := client.GetNode(nodeName)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		return nil, fmt.Errorf("can't find the node for the pod'%v' in namespace '%v'", podName, namespace)
 	}
 	return r, nil
 }


### PR DESCRIPTION
This PR introduces a new parameter for the actionner `kubernetes:labelize`:

```yaml
    - action: Labelize Node
      actionner: kubernetes:labelize
      parameters:
        level: node
```

The allowed values are `node` and `pod` (default).

Once merged, this PR must must merged too https://github.com/falco-talon/falco-talon/pull/228