### PR TITLE
New actionner kubernetes:cordon

### DIFF
--- a/actionners/actionners.go
+++ b/actionners/actionners.go
@@ -7,6 +7,7 @@ import (
 	lambdaInvoke "github.com/falco-talon/falco-talon/actionners/aws/lambda"
 
 	calicoNetworkpolicy "github.com/falco-talon/falco-talon/actionners/calico/networkpolicy"
+	k8sCordon "github.com/falco-talon/falco-talon/actionners/kubernetes/cordon"
 	k8sDelete "github.com/falco-talon/falco-talon/actionners/kubernetes/delete"
 	k8sExec "github.com/falco-talon/falco-talon/actionners/kubernetes/exec"
 	k8sLabel "github.com/falco-talon/falco-talon/actionners/kubernetes/label"
@@ -133,6 +134,17 @@ func GetDefaultActionners() *Actionners {
 				},
 				CheckParameters: nil,
 				Action:          k8sDelete.Action,
+			},
+			&Actionner{
+				Category:        "kubernetes",
+				Name:            "cordon",
+				DefaultContinue: true,
+				Init:            k8s.Init,
+				Checks: []checkActionner{
+					k8sChecks.CheckPodExist,
+				},
+				CheckParameters: nil,
+				Action:          k8sCordon.Action,
 			},
 			&Actionner{
 				Category:        "aws",

--- a/actionners/kubernetes/cordon/cordon.go
+++ b/actionners/kubernetes/cordon/cordon.go
@@ -1,0 +1,68 @@
+package cordon
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/falco-talon/falco-talon/internal/events"
+	kubernetes "github.com/falco-talon/falco-talon/internal/kubernetes/client"
+	"github.com/falco-talon/falco-talon/internal/rules"
+	"github.com/falco-talon/falco-talon/utils"
+)
+
+const (
+	jsonPatch = `[{"op": "replace", "path": "/spec/unschedulable", "value": true}]`
+)
+
+func Action(_ *rules.Action, event *events.Event) (utils.LogLine, error) {
+	podName := event.GetPodName()
+	namespace := event.GetNamespaceName()
+
+	objects := map[string]string{}
+
+	client := kubernetes.GetClient()
+
+	pod, err := client.GetPod(podName, namespace)
+	if err != nil {
+		objects["pod"] = podName
+		objects["namespace"] = namespace
+		return utils.LogLine{
+				Objects: objects,
+				Error:   err.Error(),
+				Status:  "failure",
+			},
+			err
+	}
+
+	node, err := client.GetNodeFromPod(pod)
+	if err != nil {
+		return utils.LogLine{
+				Objects: objects,
+				Error:   err.Error(),
+				Status:  "failure",
+			},
+			err
+	}
+
+	objects["node"] = node.Name
+
+	_, err = client.Clientset.CoreV1().Nodes().Patch(context.Background(), node.Name, types.JSONPatchType, []byte(jsonPatch), metav1.PatchOptions{})
+	if err != nil {
+		return utils.LogLine{
+				Objects: objects,
+				Error:   err.Error(),
+				Status:  "failure",
+			},
+			err
+	}
+
+	return utils.LogLine{
+			Objects: objects,
+			Output:  fmt.Sprintf("the node '%v' has been cordoned", node.Name),
+			Status:  "success",
+		},
+		nil
+}


### PR DESCRIPTION
New actionner `kubernetes:cordon`.

The PR to update the docs is https://github.com/falco-talon/falco-talon.github.io/pull/6

> [!NOTE]
As this PR relies on changes in the branch `node-label`, this one is the target of the branch.