### PR TITLE
move context fields from the output_fields field to a the context field

### DIFF
--- a/actionners/actionners.go
+++ b/actionners/actionners.go
@@ -365,7 +365,7 @@ func StartConsumer(eventsC <-chan string) {
 			for _, a := range i.GetActions() {
 				e := new(events.Event)
 				*e = *event
-				i.ExtendOutputFields(e, a)
+				i.AddContext(e, a)
 				if err := runAction(i, a, e); err != nil && a.IgnoreErrors == falseStr {
 					break
 				}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -21,6 +21,7 @@ type Event struct {
 	Time         time.Time              `json:"time"`
 	Source       string                 `json:"source"`
 	OutputFields map[string]interface{} `json:"output_fields"`
+	Context      map[string]interface{} `json:"context"`
 	Tags         []interface{}          `json:"tags"`
 }
 
@@ -129,6 +130,10 @@ func (event *Event) ExportEnvVars() {
 		key := strings.ReplaceAll(strings.ToUpper(i), ".", "_")
 		key = strings.ReplaceAll(key, "[", "_")
 		key = strings.ReplaceAll(key, "]", "")
+		os.Setenv(key, fmt.Sprintf("%v", j))
+	}
+	for i, j := range event.Context {
+		key := strings.ReplaceAll(strings.ToUpper(i), ".", "_")
 		os.Setenv(key, fmt.Sprintf("%v", j))
 	}
 	os.Setenv("PRIORITY", event.Priority)

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -541,22 +541,22 @@ func (rule *Rule) comparePriority(event *events.Event) bool {
 	return false
 }
 
-func (rule *Rule) ExtendOutputFields(event *events.Event, action *Action) {
-	event.OutputFields[falcoTalonOutputField+"rule"] = rule.Name
+func (rule *Rule) AddContext(event *events.Event, action *Action) {
+	event.Context[falcoTalonOutputField+"rule"] = rule.Name
 	if rule.Continue != "" {
-		event.OutputFields[falcoTalonOutputField+"rule.continue"] = rule.Continue
+		event.Context[falcoTalonOutputField+"rule.continue"] = rule.Continue
 	}
 	if rule.DryRun != "" {
-		event.OutputFields[falcoTalonOutputField+"rule.dry_run"] = rule.DryRun
+		event.Context[falcoTalonOutputField+"rule.dry_run"] = rule.DryRun
 	}
-	event.OutputFields[falcoTalonOutputField+"action"] = action.Name
+	event.Context[falcoTalonOutputField+"action"] = action.Name
 	if action.Continue != "" {
-		event.OutputFields[falcoTalonOutputField+"action.continue"] = action.Continue
+		event.Context[falcoTalonOutputField+"action.continue"] = action.Continue
 	}
 	if action.IgnoreErrors != "" {
-		event.OutputFields[falcoTalonOutputField+"action.ignore_errors"] = action.IgnoreErrors
+		event.Context[falcoTalonOutputField+"action.ignore_errors"] = action.IgnoreErrors
 	}
 	j, _ := json.Marshal(action.Parameters)
-	event.OutputFields[falcoTalonOutputField+"action.parameters"] = string(j)
-	event.OutputFields[falcoTalonOutputField+"actionner"] = action.Actionner
+	event.Context[falcoTalonOutputField+"action.parameters"] = string(j)
+	event.Context[falcoTalonOutputField+"actionner"] = action.Actionner
 }


### PR DESCRIPTION
For now, Falco Talon injects in the `output_fields` field of the payload, some fields for the context like `falco-talon.action.name`. I think it's better to not mix together the elements that come from Falco itself and Falco Talon's injections.
This is why I prefer to inject a whole block `context` that will host the `falco-talon.*` keys, and more, like `aws.*` (AWS Ec2 Metadata), `gcp.*`, ...