### PR TITLE
use a smaller image for the tcpdump for a quicker cold start (pull)

### DIFF
--- a/cmd/actionners.go
+++ b/cmd/actionners.go
@@ -25,18 +25,18 @@ var actionnersListCmd = &cobra.Command{
 	Run: func(_ *cobra.Command, _ []string) {
 		defaultActionners := actionners.ListDefaultActionners()
 		type actionner struct { // nolint:govet
+			Parameters           map[string]any `yaml:"parameters"`
 			Name                 string         `yaml:"name"`
 			Category             string         `yaml:"category"`
 			Description          string         `yaml:"description"`
 			Source               string         `yaml:"source"`
+			Permissions          string         `yaml:"permissions,omitempty"`
+			Example              string         `yaml:"example,omitempty"`
+			RequiredOutputFields []string       `yaml:"required_output_fields"`
 			Continue             bool           `yaml:"continue"`
 			UseContext           bool           `yaml:"use_context"`
 			AllowOutput          bool           `yaml:"allow_output"`
 			RequireOutput        bool           `yaml:"require_output"`
-			RequiredOutputFields []string       `yaml:"required_output_fields"`
-			Parameters           map[string]any `yaml:"parameters"`
-			Permissions          string         `yaml:"permissions,omitempty"`
-			Example              string         `yaml:"example,omitempty"`
 		}
 
 		for _, i := range *defaultActionners {

--- a/internal/kubernetes/client/client.go
+++ b/internal/kubernetes/client/client.go
@@ -448,12 +448,12 @@ func GetHealthyReplicasPercent(replicaset *appsv1.ReplicaSet) (int64, error) {
 	return 100 * (healthyReplicas / totalReplicas), nil
 }
 
-func (client *Client) CreateEphemeralContainer(pod *corev1.Pod, container, name string, ttl int) error {
+func (client *Client) CreateEphemeralContainer(pod *corev1.Pod, container, name, image string, ttl int) error {
 	ec := &corev1.EphemeralContainer{
 		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
 			Name:                     name,
-			Image:                    "dockersec/tcpdump",
-			ImagePullPolicy:          corev1.PullIfNotPresent,
+			Image:                    image,
+			ImagePullPolicy:          corev1.PullAlways,
 			Command:                  []string{"sleep", fmt.Sprintf("%v", ttl)},
 			Stdin:                    true,
 			TTY:                      false,


### PR DESCRIPTION
The `kubernetes:tcpdump` actionner starts and attach an ephemeral container to the running pod, til now, the image used for that was big, that created a latency because of the time to pull. I used [`slim`](https://github.com/slimtoolkit/slim) to reduce the size by 10:


```
❯ docker images | grep tcp
issif/tcpdump                                                    latest                                                             cc7bf4810fc6   3 minutes ago    13.6MB
dockersec/tcpdump                                                latest                                                             6d2dcfe47029   5 months ago     131MB
```