### PR TITLE
Issue447

### DIFF
--- a/deployment/helm/Chart.yaml
+++ b/deployment/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.1.0
 description: React to the events from Falco
 name: falco-talon
-version: 0.1.0
+version: 0.1.1
 keywords:
   - falco
   - monitoring

--- a/deployment/helm/templates/servicemonitor.yaml
+++ b/deployment/helm/templates/servicemonitor.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.serviceMonitor.port }}
       {{- with .Values.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -254,7 +254,9 @@ config:
 serviceMonitor:
   # -- enable the deployment of a Service Monitor for the Prometheus Operator.
   enabled: false
-  # -- path at which the metrics are expose
+  # -- portname at which the metrics are exposed
+  port: http
+  # -- path at which the metrics are exposed
   path: /metrics
   # -- additionalLabels specifies labels to be added on the Service Monitor.
   additionalLabels: {}


### PR DESCRIPTION
Fixes #447  

So serviceMonitor works and there is an image that can be pulled.
Imagename on dockerhub should be v0.1.0 instead of 0.1.0 maybe

Thx for this greas software