### PR TITLE
fix various panics + fix label with a / in the key

### DIFF
--- a/actionners/calico/networkpolicy/networkpolicy.go
+++ b/actionners/calico/networkpolicy/networkpolicy.go
@@ -108,7 +108,7 @@ func Register() *Actionner {
 }
 
 func (a Actionner) Init() error {
-	return k8s.Init()
+	return calico.Init()
 }
 
 func (a Actionner) Information() models.Information {

--- a/actionners/cilium/networkpolicy/networkpolicy.go
+++ b/actionners/cilium/networkpolicy/networkpolicy.go
@@ -111,7 +111,7 @@ func Register() *Actionner {
 }
 
 func (a Actionner) Init() error {
-	return k8s.Init()
+	return cilium.Init()
 }
 
 func (a Actionner) Information() models.Information {

--- a/actionners/kubernetes/label/label.go
+++ b/actionners/kubernetes/label/label.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -162,7 +163,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 		}
 		payload = append(payload, patch{
 			Op:    "replace",
-			Path:  metadataLabels + i,
+			Path:  metadataLabels + strings.ReplaceAll(i, "/", "~1"),
 			Value: fmt.Sprintf("%v", j),
 		})
 	}
@@ -190,7 +191,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 		}
 		payload = append(payload, patch{
 			Op:   "remove",
-			Path: metadataLabels + i,
+			Path: metadataLabels + strings.ReplaceAll(i, "/", "~1"),
 		})
 	}
 

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -113,10 +113,10 @@ var rulesPrintCmd = &cobra.Command{
 			DryRun      string   `yaml:"dry_run,omitempty"`
 			Notifiers   []string `yaml:"notifiers,omitempty"`
 			Actions     []struct {
-				Parameters map[string]interface{} `yaml:"parameters,omitempty"`
+				Parameters map[string]any `yaml:"parameters,omitempty"`
 				Output     struct {
-					Parameters map[string]interface{} `yaml:"parameters"`
-					Target     string                 `yaml:"target"`
+					Parameters map[string]any `yaml:"parameters"`
+					Target     string         `yaml:"target"`
 				} `yaml:"output,omitempty"`
 				Name               string   `yaml:"action"`
 				Description        string   `yaml:"description,omitempty"`

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -35,19 +35,19 @@ type Otel struct {
 }
 
 type Configuration struct {
-	Notifiers        map[string]map[string]interface{} `mapstructure:"notifiers"`
-	AwsConfig        AwsConfig                         `mapstructure:"aws"`
-	LogFormat        string                            `mapstructure:"log_format"`
-	KubeConfig       string                            `mapstructure:"kubeconfig"`
-	ListenAddress    string                            `mapstructure:"listen_address"`
-	MinioConfig      MinioConfig                       `mapstructure:"minio"`
-	RulesFiles       []string                          `mapstructure:"rules_files"`
-	DefaultNotifiers []string                          `mapstructure:"default_notifiers"`
-	Otel             Otel                              `mapstructure:"otel"`
-	Deduplication    deduplication                     `mapstructure:"deduplication"`
-	ListenPort       int                               `mapstructure:"listen_port"`
-	WatchRules       bool                              `mapstructure:"watch_rules"`
-	PrintAllEvents   bool                              `mapstructure:"print_all_events"`
+	Notifiers        map[string]map[string]any `mapstructure:"notifiers"`
+	AwsConfig        AwsConfig                 `mapstructure:"aws"`
+	LogFormat        string                    `mapstructure:"log_format"`
+	KubeConfig       string                    `mapstructure:"kubeconfig"`
+	ListenAddress    string                    `mapstructure:"listen_address"`
+	MinioConfig      MinioConfig               `mapstructure:"minio"`
+	RulesFiles       []string                  `mapstructure:"rules_files"`
+	DefaultNotifiers []string                  `mapstructure:"default_notifiers"`
+	Otel             Otel                      `mapstructure:"otel"`
+	Deduplication    deduplication             `mapstructure:"deduplication"`
+	ListenPort       int                       `mapstructure:"listen_port"`
+	WatchRules       bool                      `mapstructure:"watch_rules"`
+	PrintAllEvents   bool                      `mapstructure:"print_all_events"`
 }
 
 type deduplication struct {

--- a/internal/context/aws/aws.go
+++ b/internal/context/aws/aws.go
@@ -7,7 +7,7 @@ import (
 	"github.com/falco-talon/falco-talon/internal/events"
 )
 
-func GetAwsContext(_ *events.Event) (map[string]interface{}, error) {
+func GetAwsContext(_ *events.Event) (map[string]any, error) {
 	imdsClient := aws.GetImdsClient()
 
 	info, err := imdsClient.GetIAMInfo(context.Background(), nil)
@@ -20,7 +20,7 @@ func GetAwsContext(_ *events.Event) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	elements["aws.instance_profile_arn"] = info.InstanceProfileArn
 	elements["aws.instance_profile_id"] = info.InstanceProfileID
 	elements["aws.region"] = region.Region

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -16,7 +16,7 @@ import (
 	"github.com/falco-talon/falco-talon/internal/events"
 )
 
-func GetContext(actx context.Context, source string, event *events.Event) (map[string]interface{}, error) {
+func GetContext(actx context.Context, source string, event *events.Event) (map[string]any, error) {
 	tracer := traces.GetTracer()
 
 	_, span := tracer.Start(actx, "context",
@@ -24,7 +24,7 @@ func GetContext(actx context.Context, source string, event *events.Event) (map[s
 	)
 	defer span.End()
 
-	context := make(map[string]interface{})
+	context := make(map[string]any)
 	var err error
 
 	switch source {

--- a/internal/context/kubernetes/kubernetes.go
+++ b/internal/context/kubernetes/kubernetes.go
@@ -5,7 +5,7 @@ import (
 	kubernetes "github.com/falco-talon/falco-talon/internal/kubernetes/client"
 )
 
-func GetNodeContext(event *events.Event) (map[string]interface{}, error) {
+func GetNodeContext(event *events.Event) (map[string]any, error) {
 	podName := event.GetPodName()
 	namespace := event.GetNamespaceName()
 
@@ -19,7 +19,7 @@ func GetNodeContext(event *events.Event) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	elements["node.hostname"] = node.Labels["kubernetes.io/hostname"]
 	elements["node.instancetype"] = node.Labels["node.kubernetes.io/instance-type"]
 	elements["node.role"] = node.Labels["kubernetes.io/role"]

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -11,16 +11,16 @@ import (
 )
 
 type Event struct {
-	TraceID      string                 `json:"trace_id"`
-	Output       string                 `json:"output"`
-	Priority     string                 `json:"priority"`
-	Rule         string                 `json:"rule"`
-	Hostname     string                 `json:"hostname"`
-	Time         time.Time              `json:"time"`
-	Source       string                 `json:"source"`
-	OutputFields map[string]interface{} `json:"output_fields"`
-	Context      map[string]interface{} `json:"context"`
-	Tags         []interface{}          `json:"tags"`
+	TraceID      string         `json:"trace_id"`
+	Output       string         `json:"output"`
+	Priority     string         `json:"priority"`
+	Rule         string         `json:"rule"`
+	Hostname     string         `json:"hostname"`
+	Time         time.Time      `json:"time"`
+	Source       string         `json:"source"`
+	OutputFields map[string]any `json:"output_fields"`
+	Context      map[string]any `json:"context"`
+	Tags         []any          `json:"tags"`
 }
 
 const (
@@ -123,9 +123,9 @@ func (event *Event) GetRemoteProtocol() string {
 	return ""
 }
 
-func (event *Event) AddContext(elements map[string]interface{}) {
+func (event *Event) AddContext(elements map[string]any) {
 	if event.Context == nil {
-		event.Context = make(map[string]interface{})
+		event.Context = make(map[string]any)
 	}
 	if len(elements) == 0 {
 		return

--- a/internal/kubernetes/client/client.go
+++ b/internal/kubernetes/client/client.go
@@ -58,7 +58,7 @@ type KubernetesClient interface {
 	GetStatefulsetFromPod(pod *corev1.Pod) (*appsv1.StatefulSet, error)
 	GetReplicasetFromPod(pod *corev1.Pod) (*appsv1.ReplicaSet, error)
 	GetNodeFromPod(pod *corev1.Pod) (*corev1.Node, error)
-	GetTarget(resource, name, namespace string) (interface{}, error)
+	GetTarget(resource, name, namespace string) (any, error)
 	GetNamespace(name string) (*corev1.Namespace, error)
 	GetConfigMap(name, namespace string) (*corev1.ConfigMap, error)
 	GetSecret(name, namespace string) (*corev1.Secret, error)
@@ -259,7 +259,7 @@ func (client Client) GetNodeFromPod(pod *corev1.Pod) (*corev1.Node, error) {
 	return r, nil
 }
 
-func (client Client) GetTarget(resource, name, namespace string) (interface{}, error) {
+func (client Client) GetTarget(resource, name, namespace string) (any, error) {
 	switch resource {
 	case "namespaces":
 		return client.GetNamespace(name)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -21,4 +21,4 @@ type Data struct {
 	Bytes   []byte
 }
 
-type Parameters interface{}
+type Parameters any

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -16,14 +16,14 @@ import (
 )
 
 type Action struct {
-	Output             Output                 `yaml:"output,omitempty"`
-	Parameters         map[string]interface{} `yaml:"parameters,omitempty"`
-	Name               string                 `yaml:"action"`
-	Description        string                 `yaml:"description"`
-	Actionner          string                 `yaml:"actionner"`
-	Continue           string                 `yaml:"continue,omitempty"`      // can't be a bool because an omitted value == false by default
-	IgnoreErrors       string                 `yaml:"ignore_errors,omitempty"` // can't be a bool because an omitted value == false by default
-	AdditionalContexts []string               `yaml:"additional_contexts,omitempty"`
+	Output             Output         `yaml:"output,omitempty"`
+	Parameters         map[string]any `yaml:"parameters,omitempty"`
+	Name               string         `yaml:"action"`
+	Description        string         `yaml:"description"`
+	Actionner          string         `yaml:"actionner"`
+	Continue           string         `yaml:"continue,omitempty"`      // can't be a bool because an omitted value == false by default
+	IgnoreErrors       string         `yaml:"ignore_errors,omitempty"` // can't be a bool because an omitted value == false by default
+	AdditionalContexts []string       `yaml:"additional_contexts,omitempty"`
 }
 
 type Rule struct {
@@ -49,8 +49,8 @@ type Match struct {
 }
 
 type Output struct {
-	Parameters map[string]interface{} `yaml:"parameters"`
-	Target     string                 `yaml:"target"`
+	Parameters map[string]any `yaml:"parameters"`
+	Target     string         `yaml:"target"`
 }
 
 type outputfield struct {
@@ -113,7 +113,7 @@ func ParseRules(files []string) *[]*Rule {
 						rule.Actions[n].AdditionalContexts = action.AdditionalContexts
 					}
 					if rule.Actions[n].Parameters == nil && len(action.Parameters) != 0 {
-						rule.Actions[n].Parameters = make(map[string]interface{})
+						rule.Actions[n].Parameters = make(map[string]any)
 					}
 					for k, v := range action.Parameters {
 						rt := reflect.TypeOf(v)
@@ -129,17 +129,17 @@ func ParseRules(files []string) *[]*Rule {
 						case reflect.Slice, reflect.Array:
 							w := v
 							if rule.Actions[n].Parameters[k] == nil {
-								rule.Actions[n].Parameters[k] = []interface{}{w}
+								rule.Actions[n].Parameters[k] = []any{w}
 							} else {
-								w = append(w.([]interface{}), rule.Actions[n].Parameters[k].([]interface{})...)
+								w = append(w.([]any), rule.Actions[n].Parameters[k].([]any)...)
 							}
 							rule.Actions[n].Parameters[k] = w
 						case reflect.Map:
-							for s, t := range v.(map[string]interface{}) {
+							for s, t := range v.(map[string]any) {
 								if rule.Actions[n].Parameters[k] == nil {
-									rule.Actions[n].Parameters[k] = make(map[string]interface{})
+									rule.Actions[n].Parameters[k] = make(map[string]any)
 								}
-								rule.Actions[n].Parameters[k].(map[string]interface{})[s] = t
+								rule.Actions[n].Parameters[k].(map[string]any)[s] = t
 							}
 						default:
 							if rule.Actions[n].Parameters[k] == nil {
@@ -164,20 +164,23 @@ func ParseRules(files []string) *[]*Rule {
 						case reflect.Slice, reflect.Array:
 							w := v
 							if rule.Actions[n].Output.Parameters[k] == nil {
-								rule.Actions[n].Output.Parameters[k] = []interface{}{w}
+								rule.Actions[n].Output.Parameters[k] = []any{w}
 							} else {
-								w = append(w.([]interface{}), rule.Actions[n].Output.Parameters[k].([]interface{})...)
+								w = append(w.([]any), rule.Actions[n].Output.Parameters[k].([]any)...)
 							}
 							rule.Actions[n].Output.Parameters[k] = w
 						case reflect.Map:
-							for s, t := range v.(map[string]interface{}) {
+							for s, t := range v.(map[string]any) {
 								if rule.Actions[n].Output.Parameters[k] == nil {
-									rule.Actions[n].Output.Parameters[k] = make(map[string]interface{})
+									rule.Actions[n].Output.Parameters[k] = make(map[string]any)
 								}
-								rule.Actions[n].Output.Parameters[k].(map[string]interface{})[s] = t
+								rule.Actions[n].Output.Parameters[k].(map[string]any)[s] = t
 							}
 						default:
 							if rule.Actions[n].Output.Parameters[k] == nil {
+								if rule.Actions[n].Output.Parameters == nil {
+									rule.Actions[n].Output.Parameters = make(map[string]any)
+								}
 								rule.Actions[n].Output.Parameters[k] = v
 							}
 						}
@@ -275,7 +278,7 @@ func extractActionsRules(files []string) (*[]*Action, *[]*Rule, error) {
 					i.IgnoreErrors = l.IgnoreErrors
 				}
 				if i.Parameters == nil && len(l.Parameters) != 0 {
-					i.Parameters = make(map[string]interface{})
+					i.Parameters = make(map[string]any)
 				}
 				i.AdditionalContexts = append(i.AdditionalContexts, l.AdditionalContexts...)
 				for k, v := range l.Parameters {
@@ -290,16 +293,16 @@ func extractActionsRules(files []string) (*[]*Action, *[]*Rule, error) {
 					switch rt.Kind() {
 					case reflect.Slice, reflect.Array:
 						if i.Parameters[k] == nil {
-							i.Parameters[k] = []interface{}{v}
+							i.Parameters[k] = []any{v}
 						} else {
-							i.Parameters[k] = append(i.Parameters[k].([]interface{}), v.([]interface{})...)
+							i.Parameters[k] = append(i.Parameters[k].([]any), v.([]any)...)
 						}
 					case reflect.Map:
-						for s, t := range v.(map[string]interface{}) {
+						for s, t := range v.(map[string]any) {
 							if i.Parameters[k] == nil {
-								i.Parameters[k] = make(map[string]interface{})
+								i.Parameters[k] = make(map[string]any)
 							}
-							i.Parameters[k].(map[string]interface{})[s] = t
+							i.Parameters[k].(map[string]any)[s] = t
 						}
 					default:
 						i.Parameters[k] = v
@@ -317,16 +320,16 @@ func extractActionsRules(files []string) (*[]*Action, *[]*Rule, error) {
 					switch rt.Kind() {
 					case reflect.Slice, reflect.Array:
 						if i.Output.Parameters[k] == nil {
-							i.Output.Parameters[k] = []interface{}{v}
+							i.Output.Parameters[k] = []any{v}
 						} else {
-							i.Output.Parameters[k] = append(i.Output.Parameters[k].([]interface{}), v.([]interface{})...)
+							i.Output.Parameters[k] = append(i.Output.Parameters[k].([]any), v.([]any)...)
 						}
 					case reflect.Map:
-						for s, t := range v.(map[string]interface{}) {
+						for s, t := range v.(map[string]any) {
 							if i.Output.Parameters[k] == nil {
-								i.Output.Parameters[k] = make(map[string]interface{})
+								i.Output.Parameters[k] = make(map[string]any)
 							}
-							i.Output.Parameters[k].(map[string]interface{})[s] = t
+							i.Output.Parameters[k].(map[string]any)[s] = t
 						}
 					default:
 						i.Output.Parameters[k] = v
@@ -507,7 +510,7 @@ func (action *Action) GetActionnerName() string {
 	return strings.Split(action.Actionner, ":")[1]
 }
 
-func (action *Action) GetParameters() map[string]interface{} {
+func (action *Action) GetParameters() map[string]any {
 	return action.Parameters
 }
 
@@ -526,7 +529,7 @@ func (output *Output) GetTarget() string {
 	return output.Target
 }
 
-func (output *Output) GetParameters() map[string]interface{} {
+func (output *Output) GetParameters() map[string]any {
 	return output.Parameters
 }
 
@@ -646,7 +649,7 @@ func (rule *Rule) comparePriority(event *events.Event) bool {
 }
 
 func (rule *Rule) AddFalcoTalonContext(event *events.Event, action *Action) {
-	elements := make(map[string]interface{})
+	elements := make(map[string]any)
 	elements[falcoTalonContextPrefix+"rule"] = rule.Name
 	if rule.Continue != "" {
 		elements[falcoTalonContextPrefix+"rule.continue"] = rule.Continue

--- a/notifiers/elasticsearch/elasticsearch.go
+++ b/notifiers/elasticsearch/elasticsearch.go
@@ -55,7 +55,7 @@ func Register() *Notifier {
 	return new(Notifier)
 }
 
-func (n Notifier) Init(fields map[string]interface{}) error {
+func (n Notifier) Init(fields map[string]any) error {
 	parameters = new(Parameters)
 	parameters = utils.SetFields(parameters, fields).(*Parameters)
 	if err := checkParameters(parameters); err != nil {
@@ -71,7 +71,7 @@ func (n Notifier) Init(fields map[string]interface{}) error {
 				client.SetHTTPMethod("PUT")
 				m := strings.ReplaceAll(mapping, "${SHARDS}", fmt.Sprintf("%v", parameters.NumberOfShards))
 				m = strings.ReplaceAll(m, "${REPLICAS}", fmt.Sprintf("%v", parameters.NumberOfReplicas))
-				j := make(map[string]interface{})
+				j := make(map[string]any)
 				if err := json.Unmarshal([]byte(m), &j); err != nil {
 					return err
 				}

--- a/notifiers/http/client.go
+++ b/notifiers/http/client.go
@@ -109,7 +109,7 @@ func NewClient(httpMethod, contentType, userAgent string, headers map[string]str
 	}
 }
 
-func (c *Client) Request(u string, payload interface{}) error {
+func (c *Client) Request(u string, payload any) error {
 	// defer + recover to catch panic if output doesn't respond
 	defer func() {
 		if err := recover(); err != nil {

--- a/notifiers/k8sevents/k8sevents.go
+++ b/notifiers/k8sevents/k8sevents.go
@@ -77,7 +77,7 @@ func Register() *Notifier {
 	return new(Notifier)
 }
 
-func (n Notifier) Init(_ map[string]interface{}) error { return nil }
+func (n Notifier) Init(_ map[string]any) error { return nil }
 
 func (n Notifier) Information() models.Information {
 	return models.Information{

--- a/notifiers/loki/loki.go
+++ b/notifiers/loki/loki.go
@@ -52,7 +52,7 @@ func Register() *Notifier {
 	return new(Notifier)
 }
 
-func (n Notifier) Init(fields map[string]interface{}) error {
+func (n Notifier) Init(fields map[string]any) error {
 	parameters = new(Parameters)
 	parameters = utils.SetFields(parameters, fields).(*Parameters)
 	if err := checkParameters(parameters); err != nil {

--- a/notifiers/notifiers.go
+++ b/notifiers/notifiers.go
@@ -26,7 +26,7 @@ import (
 )
 
 type Notifier interface {
-	Init(fields map[string]interface{}) error
+	Init(fields map[string]any) error
 	Run(log utils.LogLine) error
 	Information() models.Information
 	Parameters() models.Parameters

--- a/notifiers/slack/slack.go
+++ b/notifiers/slack/slack.go
@@ -190,7 +190,7 @@ func newPayload(log utils.LogLine) Payload {
 		}
 		if log.Event != "" {
 			field.Title = "Event"
-			field.Value = "`" + log.Event + "`"
+			field.Value = "```" + log.Event + "```"
 			field.Short = false
 			fields = append(fields, field)
 		}

--- a/notifiers/slack/slack.go
+++ b/notifiers/slack/slack.go
@@ -71,7 +71,7 @@ func Register() *Notifier {
 	return new(Notifier)
 }
 
-func (n Notifier) Init(fields map[string]interface{}) error {
+func (n Notifier) Init(fields map[string]any) error {
 	parameters = new(Parameters)
 	parameters = utils.SetFields(parameters, fields).(*Parameters)
 	if err := checkParameters(parameters); err != nil {

--- a/notifiers/smtp/smtp.go
+++ b/notifiers/smtp/smtp.go
@@ -70,7 +70,7 @@ func Register() *Notifier {
 	return new(Notifier)
 }
 
-func (n Notifier) Init(fields map[string]interface{}) error {
+func (n Notifier) Init(fields map[string]any) error {
 	parameters = new(Parameters)
 	parameters = utils.SetFields(parameters, fields).(*Parameters)
 	if err := checkParameters(parameters); err != nil {

--- a/notifiers/webhook/webhook.go
+++ b/notifiers/webhook/webhook.go
@@ -39,7 +39,7 @@ func Register() *Notifier {
 	return new(Notifier)
 }
 
-func (n Notifier) Init(fields map[string]interface{}) error {
+func (n Notifier) Init(fields map[string]any) error {
 	parameters = new(Parameters)
 	parameters = utils.SetFields(parameters, fields).(*Parameters)
 	if err := checkParameters(parameters); err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -95,7 +95,7 @@ func PrintLog(level string, line LogLine) {
 		if *logFormat != colorStr {
 			output.NoColor = true
 		}
-		output.FormatFieldValue = func(i interface{}) string {
+		output.FormatFieldValue = func(i any) string {
 			return fmt.Sprintf("%s", i)
 		}
 		log = zerolog.New(output).With().Timestamp().Logger()
@@ -172,7 +172,7 @@ func PrintLog(level string, line LogLine) {
 	}
 }
 
-func SetFields(structure interface{}, fields map[string]interface{}) interface{} {
+func SetFields(structure any, fields map[string]any) any {
 	valueOf := reflect.ValueOf(structure)
 	if valueOf.Kind() == reflect.Ptr {
 		valueOf = valueOf.Elem()
@@ -233,7 +233,7 @@ func SetFields(structure interface{}, fields map[string]interface{}) interface{}
 	return structure
 }
 
-func ValidateStruct(s interface{}) error {
+func ValidateStruct(s any) error {
 	err := validate.Struct(s)
 	if err != nil {
 		return err
@@ -249,7 +249,7 @@ func AddCustomValidation(tag string, fn validator.Func) error {
 	return nil
 }
 
-func DecodeParams(params map[string]interface{}, result interface{}) error {
+func DecodeParams(params map[string]any, result any) error {
 	// Decode parameters into the struct
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName: "mapstructure",


### PR DESCRIPTION
```
2024-09-30T19:58:47+02:00 INF match event="Outbound Connection to Suspicious IPs" output=test priority=Critical rule="Suspicious outbound connection" source=syscall trace_id=68d3fa233f4589158232e8705fc5bef8
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1fdfb1b]

goroutine 10 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
        /home/thomas/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.30.0/trace/span.go:398 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc0010cc820, {0x0, 0x0, 0xc0008297f8?})
        /home/thomas/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.30.0/trace/span.go:430 +0x9dc
panic({0x2bf97c0?, 0x4fdf420?})
        /usr/lib/go/src/runtime/panic.go:785 +0x132
github.com/falco-talon/falco-talon/actionners/calico/networkpolicy.Actionner.Run({}, _, _)
        /home/thomas/src/github.com/falco-talon/actionners/calico/networkpolicy/networkpolicy.go:287 +0x10db
github.com/falco-talon/falco-talon/actionners.runAction({0x35eb0e0, 0xc0010aa4e0}, 0xc000edde60, 0xd?, 0xc00107e0a0)
        /home/thomas/src/github.com/falco-talon/actionners/actionners.go:222 +0x17a3
github.com/falco-talon/falco-talon/actionners.StartConsumer(0xc000f69110)
        /home/thomas/src/github.com/falco-talon/actionners/actionners.go:539 +0x14ac
created by github.com/falco-talon/falco-talon/cmd.init.func6 in goroutine 1
        /home/thomas/src/github.com/falco-talon/cmd/server.go:245 +0x80b
exit status 2
```

```
2024-09-30T19:18:59+02:00 ERR action error="the server rejected our request due to an error in our request" action="Label Pod as Compromised" actionner=kubernetes:label event=test namespace=default pod=cncf-55696bc998-z5pwl rule="Contact K8S API Server From Container" status=failure trace_id=93af52b5ae6e2f226d478720dd05cf99
```

```
❯ falco-talon rules check -r rules.yaml
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/falco-talon/falco-talon/internal/rules.ParseRules({0xc000ef7e20?, 0x30bb653?, 0xc00019f948?})
        github.com/falco-talon/falco-talon/internal/rules/rules.go:181 +0x1e06
github.com/falco-talon/falco-talon/cmd.init.func4(0x4febd40, {0x30b99a3?, 0x4?, 0x30b995b?})
        github.com/falco-talon/falco-talon/cmd/rules.go:35 +0x112
github.com/spf13/cobra.(*Command).execute(0x4febd40, {0xc000f01c60, 0x2, 0x2})
        github.com/spf13/cobra@v1.8.1/command.go:989 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0x4feb780)
        github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/falco-talon/falco-talon/cmd.Execute()
        github.com/falco-talon/falco-talon/cmd/root.go:22 +0x25
main.main()
        github.com/falco-talon/falco-talon/main.go:8 +0xf
```

